### PR TITLE
Ellipsoid dynobench

### DIFF
--- a/include/dynobench/integrator2_3d.hpp
+++ b/include/dynobench/integrator2_3d.hpp
@@ -42,7 +42,7 @@ struct Integrator2_3d_params {
   double radius = 0.1;
   Eigen::Vector2d distance_weights = Eigen::Vector2d(1, .5);
   Eigen::Vector2d size = Eigen::Vector2d(.5, .25);
-
+  Eigen::Vector3d radii = Eigen::Vector3d(.12, .12, .3); // from tro paper
   void read_from_yaml(const char *file);
   void read_from_yaml(YAML::Node &node);
 

--- a/include/dynobench/integrator2_3d.hpp
+++ b/include/dynobench/integrator2_3d.hpp
@@ -39,7 +39,7 @@ struct Integrator2_3d_params {
   double min_acc = -2.0;
   std::string filename = "";
   std::string shape = "sphere";
-  double radius = 0.1;
+  double radius = 0.05;
   Eigen::Vector2d distance_weights = Eigen::Vector2d(1, .5);
   Eigen::Vector2d size = Eigen::Vector2d(.5, .25);
   Eigen::Vector3d radii = Eigen::Vector3d(.12, .12, .3); // from tro paper

--- a/include/dynobench/joint_robot.hpp
+++ b/include/dynobench/joint_robot.hpp
@@ -20,7 +20,12 @@ struct Joint_robot : Model_robot {
 
   std::vector<fcl::CollisionObjectd *> part_objs_;  // *
   std::vector<fcl::CollisionObjectd *> robot_objs_; // *
+  std::vector<fcl::CollisionObjectd *> rf_part_objs_;  // * for the residual force
+  std::vector<fcl::CollisionObjectd *> rf_robot_objs_; // * for the residual force
   //
+  // params, that NEEDS to be relocated
+  bool residual_force = true; // when residual force is taken into account, and inter-robot collision with ellipsoid shape
+  Eigen::Vector3d radii = Eigen::Vector3d(.12, .12, .3); // from tro paper
 
   std::vector<int> nxs;
 

--- a/models/integrator2_3d_v0.yaml
+++ b/models/integrator2_3d_v0.yaml
@@ -1,4 +1,3 @@
 dynamics: "integrator2_3d"
-shape: "sphere"
-radius: 0.05
+shape: "ellipsoid"
 # use default parameters

--- a/models/integrator2_3d_v0.yaml
+++ b/models/integrator2_3d_v0.yaml
@@ -1,3 +1,2 @@
 dynamics: "integrator2_3d"
-shape: "ellipsoid"
 # use default parameters

--- a/src/integrator2_3d.cpp
+++ b/src/integrator2_3d.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <fcl/geometry/shape/box.h>
 #include <fcl/geometry/shape/sphere.h>
+#include <fcl/geometry/shape/ellipsoid.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -87,6 +88,9 @@ Integrator2_3d::Integrator2_3d(const Integrator2_3d_params &params,
   } else if (params.shape == "sphere") {
     collision_geometries.push_back(
         std::make_shared<fcl::Sphered>(params.radius));
+  } else if (params.shape == "ellipsoid") {
+    collision_geometries.push_back(
+        std::make_shared<fcl::Ellipsoidd>(params.radii));
   } else {
     ERROR_WITH_INFO("not implemented");
   }

--- a/src/joint_robot.cpp
+++ b/src/joint_robot.cpp
@@ -136,6 +136,11 @@ Joint_robot::Joint_robot(
   for (size_t i = 0; i < collision_geometries.size(); i++) {
     auto robot_part = new fcl::CollisionObject(collision_geometries[i]);
     part_objs_.push_back(robot_part);
+    if(residual_force){
+      std::shared_ptr<fcl::Ellipsoidd> ellipsoid = std::make_shared<fcl::Ellipsoidd>(radii);
+      auto rf_robot_part = new fcl::CollisionObjectd(ellipsoid);
+      rf_part_objs_.push_back(rf_robot_part);
+    }
   }
 }
 
@@ -257,6 +262,7 @@ void Joint_robot::collision_distance(const Eigen::Ref<const Eigen::VectorXd> &x,
                                      CollisionOut &cout) {
   double min_dist = std::numeric_limits<double>::max();
   bool check_parts = true;
+  
   if (env) {
     transformation_collision_geometries(x, ts_data);
     DYNO_CHECK_EQ(collision_geometries.size(), ts_data.size(), AT);
@@ -282,9 +288,22 @@ void Joint_robot::collision_distance(const Eigen::Ref<const Eigen::VectorXd> &x,
                     fcl::DefaultDistanceFunction<double>);
       min_dist = std::min(min_dist, distance_data.result.min_distance);
     }
-
+    // robot/robot checking
     if (check_parts) {
-      col_mng_robots_->registerObjects(robot_objs_);
+      if(residual_force){
+        rf_robot_objs_.clear();
+        for (size_t i = 0; i < ts_data.size(); i++) {
+          fcl::Transform3d &transform = ts_data[i];
+          auto rf_robot_co = rf_part_objs_[i];
+          rf_robot_co->setTranslation(transform.translation());
+          rf_robot_co->setRotation(transform.rotation());
+          rf_robot_co->computeAABB();
+          rf_robot_objs_.push_back(rf_robot_co);
+        }
+        col_mng_robots_->registerObjects(rf_robot_objs_);
+      }
+      else
+        col_mng_robots_->registerObjects(robot_objs_);
       fcl::DefaultDistanceData<double> inter_robot_distance_data;
       inter_robot_distance_data.request.enable_signed_distance = true;
 


### PR DESCRIPTION
- support ellipsoid shape collision object for inter-robot collision, while robot-env is spherical shape of radius=0.05 in order to be able to expand nodes passing through the window
- the flag for residual or not is in .hpp file, maybe should be in some params file (.yaml)
- checked with benchmarking (drone12c looks good, and all n >=16 fails as before)