### PR TITLE
Support static obstacles dynobench

### DIFF
--- a/envs/multirobot/meta-robot/drone32c/parallel_opt.yaml
+++ b/envs/multirobot/meta-robot/drone32c/parallel_opt.yaml
@@ -1,4 +1,4 @@
-result: 
+result:
 -
   time_stamp: 0
   cost: 19.9

--- a/src/joint_robot.cpp
+++ b/src/joint_robot.cpp
@@ -298,6 +298,7 @@ void Joint_robot::__collision_distance(
     }
     cout.distance = min_dist;
   } else {
+    std::cout << "no _env in collision_distance, max" << std::endl;
     cout.distance = max__;
   }
 }

--- a/src/joint_robot.cpp
+++ b/src/joint_robot.cpp
@@ -281,6 +281,8 @@ void Joint_robot::__collision_distance(
       distance_data.request.enable_signed_distance = true;
       _env->distance(robot_co, &distance_data,
                      fcl::DefaultDistanceFunction<double>);
+      // if(distance_data.result.min_distance < 0)
+        // std::cout << "collision with the env, robot " << i << std::endl;
       min_dist = std::min(min_dist, distance_data.result.min_distance);
     }
 

--- a/src/motions.cpp
+++ b/src/motions.cpp
@@ -770,7 +770,7 @@ void load_time_varying_env(Model_robot &robot, const Problem &problem) {
     auto &obs_type = obs.type;
     auto &size = obs.size;
     auto &center = obs.center;
-// 
+//
     if (obs_type == "box") {
       std::shared_ptr<fcl::CollisionGeometryd> geom;
       geom.reset(new fcl::Boxd(size(0), size(1),
@@ -795,7 +795,7 @@ void load_time_varying_env(Model_robot &robot, const Problem &problem) {
       auto tree_co = new fcl::CollisionObjectd(
           std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
       robot.obstacles.push_back(tree_co);
-// 
+//
     } else {
       throw std::runtime_error("Unknown obstacle type! --" + obs_type);
     }

--- a/src/motions.cpp
+++ b/src/motions.cpp
@@ -766,43 +766,43 @@ void load_time_varying_env(Model_robot &robot, const Problem &problem) {
   double ref_size = 1.;
 
   // static obstacles
-  for (const auto &obs : problem.obstacles) {
-    auto &obs_type = obs.type;
-    auto &size = obs.size;
-    auto &center = obs.center;
+  // for (const auto &obs : problem.obstacles) {
+  //   auto &obs_type = obs.type;
+  //   auto &size = obs.size;
+  //   auto &center = obs.center;
 
-    if (obs_type == "box") {
-      std::shared_ptr<fcl::CollisionGeometryd> geom;
-      geom.reset(new fcl::Boxd(size(0), size(1),
-                               size.size() == 3 ? size(2) : ref_size));
-      auto co = new fcl::CollisionObjectd(geom);
-      co->setTranslation(fcl::Vector3d(center(0), center(1),
-                                       size.size() == 3 ? center(2) : ref_pos));
-      co->computeAABB();
-      robot.obstacles.push_back(co);
-    } else if (obs_type == "sphere") {
-      std::shared_ptr<fcl::CollisionGeometryd> geom;
-      geom.reset(new fcl::Sphered(size(0)));
-      auto co = new fcl::CollisionObjectd(geom);
-      co->setTranslation(fcl::Vector3d(
-          center(0), center(1), center.size() == 3 ? center(2) : ref_pos));
-      co->computeAABB();
-      robot.obstacles.push_back(co);
-    } else if (obs_type == "octomap") {
-      OcTree *octTree = new OcTree(obs.octomap_file);
-      fcl::OcTree<double> *fcl_tree = new fcl::OcTree<double>(
-          std::shared_ptr<const octomap::OcTree>(octTree));
-      auto tree_co = new fcl::CollisionObjectd(
-          std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
-      robot.obstacles.push_back(tree_co);
+  //   if (obs_type == "box") {
+  //     std::shared_ptr<fcl::CollisionGeometryd> geom;
+  //     geom.reset(new fcl::Boxd(size(0), size(1),
+  //                              size.size() == 3 ? size(2) : ref_size));
+  //     auto co = new fcl::CollisionObjectd(geom);
+  //     co->setTranslation(fcl::Vector3d(center(0), center(1),
+  //                                      size.size() == 3 ? center(2) : ref_pos));
+  //     co->computeAABB();
+  //     robot.obstacles.push_back(co);
+  //   } else if (obs_type == "sphere") {
+  //     std::shared_ptr<fcl::CollisionGeometryd> geom;
+  //     geom.reset(new fcl::Sphered(size(0)));
+  //     auto co = new fcl::CollisionObjectd(geom);
+  //     co->setTranslation(fcl::Vector3d(
+  //         center(0), center(1), center.size() == 3 ? center(2) : ref_pos));
+  //     co->computeAABB();
+  //     robot.obstacles.push_back(co);
+  //   } else if (obs_type == "octomap") {
+  //     OcTree *octTree = new OcTree(obs.octomap_file);
+  //     fcl::OcTree<double> *fcl_tree = new fcl::OcTree<double>(
+  //         std::shared_ptr<const octomap::OcTree>(octTree));
+  //     auto tree_co = new fcl::CollisionObjectd(
+  //         std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
+  //     robot.obstacles.push_back(tree_co);
 
-    } else {
-      throw std::runtime_error("Unknown obstacle type! --" + obs_type);
-    }
-  }
-  robot.env.reset(new fcl::DynamicAABBTreeCollisionManagerd());
-  robot.env->registerObjects(robot.obstacles);
-  robot.env->setup();
+  //   } else {
+  //     throw std::runtime_error("Unknown obstacle type! --" + obs_type);
+  //   }
+  // }
+  // robot.env.reset(new fcl::DynamicAABBTreeCollisionManagerd());
+  // robot.env->registerObjects(robot.obstacles);
+  // robot.env->setup();
   // moving obstacles
   for (const auto &obstacles : problem.time_varying_obstacles) {
 

--- a/src/motions.cpp
+++ b/src/motions.cpp
@@ -298,7 +298,6 @@ void Problem::read_from_yaml(const YAML::Node &env) {
 
   if (contains_moving_obstacles) {
     std::cout << "contains moving obstacles" << std::endl;
-    std::cout << "default obstacles is not parsed!" << std::endl;
   } else {
     for (const auto &obs : env["environment"]["obstacles"]) {
       std::vector<double> size_ = obs["size"].as<std::vector<double>>();

--- a/src/motions.cpp
+++ b/src/motions.cpp
@@ -490,7 +490,7 @@ double check_cols(std::shared_ptr<Model_robot> model_robot,
   for (size_t i = 0; i < xs.size(); i++) {
     auto &x = xs.at(i);
     model_robot->collision_distance(x, out);
-    std::cout << "collision distance: " << out.distance << std::endl;
+    // std::cout << "collision distance: " << out.distance << std::endl;
     if (out.distance < 0) {
       std::cout << "Warning -- col at: " << STR_V(x) << " time:" << i
                 << " distance: " << out.distance << std::endl;
@@ -766,43 +766,44 @@ void load_time_varying_env(Model_robot &robot, const Problem &problem) {
   double ref_size = 1.;
 
   // static obstacles
-  // for (const auto &obs : problem.obstacles) {
-  //   auto &obs_type = obs.type;
-  //   auto &size = obs.size;
-  //   auto &center = obs.center;
+  for (const auto &obs : problem.obstacles) {
+    auto &obs_type = obs.type;
+    auto &size = obs.size;
+    auto &center = obs.center;
+// 
+    if (obs_type == "box") {
+      std::shared_ptr<fcl::CollisionGeometryd> geom;
+      geom.reset(new fcl::Boxd(size(0), size(1),
+                               size.size() == 3 ? size(2) : ref_size));
+      auto co = new fcl::CollisionObjectd(geom);
+      co->setTranslation(fcl::Vector3d(center(0), center(1),
+                                       size.size() == 3 ? center(2) : ref_pos));
+      co->computeAABB();
+      robot.obstacles.push_back(co);
+    } else if (obs_type == "sphere") {
+      std::shared_ptr<fcl::CollisionGeometryd> geom;
+      geom.reset(new fcl::Sphered(size(0)));
+      auto co = new fcl::CollisionObjectd(geom);
+      co->setTranslation(fcl::Vector3d(
+          center(0), center(1), center.size() == 3 ? center(2) : ref_pos));
+      co->computeAABB();
+      robot.obstacles.push_back(co);
+    } else if (obs_type == "octomap") {
+      OcTree *octTree = new OcTree(obs.octomap_file);
+      fcl::OcTree<double> *fcl_tree = new fcl::OcTree<double>(
+          std::shared_ptr<const octomap::OcTree>(octTree));
+      auto tree_co = new fcl::CollisionObjectd(
+          std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
+      robot.obstacles.push_back(tree_co);
+// 
+    } else {
+      throw std::runtime_error("Unknown obstacle type! --" + obs_type);
+    }
+  }
+  robot.env.reset(new fcl::DynamicAABBTreeCollisionManagerd());
+  robot.env->registerObjects(robot.obstacles);
+  robot.env->setup();
 
-  //   if (obs_type == "box") {
-  //     std::shared_ptr<fcl::CollisionGeometryd> geom;
-  //     geom.reset(new fcl::Boxd(size(0), size(1),
-  //                              size.size() == 3 ? size(2) : ref_size));
-  //     auto co = new fcl::CollisionObjectd(geom);
-  //     co->setTranslation(fcl::Vector3d(center(0), center(1),
-  //                                      size.size() == 3 ? center(2) : ref_pos));
-  //     co->computeAABB();
-  //     robot.obstacles.push_back(co);
-  //   } else if (obs_type == "sphere") {
-  //     std::shared_ptr<fcl::CollisionGeometryd> geom;
-  //     geom.reset(new fcl::Sphered(size(0)));
-  //     auto co = new fcl::CollisionObjectd(geom);
-  //     co->setTranslation(fcl::Vector3d(
-  //         center(0), center(1), center.size() == 3 ? center(2) : ref_pos));
-  //     co->computeAABB();
-  //     robot.obstacles.push_back(co);
-  //   } else if (obs_type == "octomap") {
-  //     OcTree *octTree = new OcTree(obs.octomap_file);
-  //     fcl::OcTree<double> *fcl_tree = new fcl::OcTree<double>(
-  //         std::shared_ptr<const octomap::OcTree>(octTree));
-  //     auto tree_co = new fcl::CollisionObjectd(
-  //         std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
-  //     robot.obstacles.push_back(tree_co);
-
-  //   } else {
-  //     throw std::runtime_error("Unknown obstacle type! --" + obs_type);
-  //   }
-  // }
-  // robot.env.reset(new fcl::DynamicAABBTreeCollisionManagerd());
-  // robot.env->registerObjects(robot.obstacles);
-  // robot.env->setup();
   // moving obstacles
   for (const auto &obstacles : problem.time_varying_obstacles) {
 

--- a/src/motions.cpp
+++ b/src/motions.cpp
@@ -265,8 +265,28 @@ void Problem::read_from_yaml(const YAML::Node &env) {
   p_lb = Eigen::Map<Eigen::VectorXd>(&min_.at(0), min_.size());
   p_ub = Eigen::Map<Eigen::VectorXd>(&max_.at(0), max_.size());
 
+  // parse static obstacles anyway
+  if (env["environment"]["static_obstacles"]){
+    for (const auto &obs : env["environment"]["static_obstacles"] ) {
+      std::vector<double> size_ = obs["size"].as<std::vector<double>>();
+      Vxd size = Vxd::Map(size_.data(), size_.size());
+      auto obs_type = obs["type"].as<std::string>();
+      std::string octomap_filename;
+      if (obs_type == "octomap") {
+        octomap_filename = obs["octomap_file"].as<std::string>();
+      }
+
+      std::vector<double> center_ = obs["center"].as<std::vector<double>>();
+      Vxd center = Vxd::Map(center_.data(), center_.size());
+
+      obstacles.push_back(Obstacle{.type = obs_type,
+                                    .octomap_file = octomap_filename,
+                                    .size = size,
+                                    .center = center});
+    }
+  }
+
   // check if the environment has moving obstacles
-  //
   bool contains_moving_obstacles = false;
   if (env["environment"]["moving_obstacles"]) {
 
@@ -295,7 +315,6 @@ void Problem::read_from_yaml(const YAML::Node &env) {
       time_varying_obstacles.push_back(_obstacles);
     }
   }
-
   if (contains_moving_obstacles) {
     std::cout << "contains moving obstacles" << std::endl;
   } else {
@@ -471,6 +490,7 @@ double check_cols(std::shared_ptr<Model_robot> model_robot,
   for (size_t i = 0; i < xs.size(); i++) {
     auto &x = xs.at(i);
     model_robot->collision_distance(x, out);
+    std::cout << "collision distance: " << out.distance << std::endl;
     if (out.distance < 0) {
       std::cout << "Warning -- col at: " << STR_V(x) << " time:" << i
                 << " distance: " << out.distance << std::endl;
@@ -745,6 +765,45 @@ void load_time_varying_env(Model_robot &robot, const Problem &problem) {
   double ref_pos = 0;
   double ref_size = 1.;
 
+  // static obstacles
+  for (const auto &obs : problem.obstacles) {
+    auto &obs_type = obs.type;
+    auto &size = obs.size;
+    auto &center = obs.center;
+
+    if (obs_type == "box") {
+      std::shared_ptr<fcl::CollisionGeometryd> geom;
+      geom.reset(new fcl::Boxd(size(0), size(1),
+                               size.size() == 3 ? size(2) : ref_size));
+      auto co = new fcl::CollisionObjectd(geom);
+      co->setTranslation(fcl::Vector3d(center(0), center(1),
+                                       size.size() == 3 ? center(2) : ref_pos));
+      co->computeAABB();
+      robot.obstacles.push_back(co);
+    } else if (obs_type == "sphere") {
+      std::shared_ptr<fcl::CollisionGeometryd> geom;
+      geom.reset(new fcl::Sphered(size(0)));
+      auto co = new fcl::CollisionObjectd(geom);
+      co->setTranslation(fcl::Vector3d(
+          center(0), center(1), center.size() == 3 ? center(2) : ref_pos));
+      co->computeAABB();
+      robot.obstacles.push_back(co);
+    } else if (obs_type == "octomap") {
+      OcTree *octTree = new OcTree(obs.octomap_file);
+      fcl::OcTree<double> *fcl_tree = new fcl::OcTree<double>(
+          std::shared_ptr<const octomap::OcTree>(octTree));
+      auto tree_co = new fcl::CollisionObjectd(
+          std::shared_ptr<fcl::CollisionGeometryd>(fcl_tree));
+      robot.obstacles.push_back(tree_co);
+
+    } else {
+      throw std::runtime_error("Unknown obstacle type! --" + obs_type);
+    }
+  }
+  robot.env.reset(new fcl::DynamicAABBTreeCollisionManagerd());
+  robot.env->registerObjects(robot.obstacles);
+  robot.env->setup();
+  // moving obstacles
   for (const auto &obstacles : problem.time_varying_obstacles) {
 
     std::vector<fcl::CollisionObjectd *> _obs;


### PR DESCRIPTION
Here, load_time_varying_env also activated robot->env, which is needed for feasibility_update function. Now, the manually created environment has static obstacles also, which is added to each timestamp among moving neighbors.